### PR TITLE
Modify to return getline() value when exit

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline.vim
+++ b/autoload/vital/__latest__/Over/Commandline.vim
@@ -228,7 +228,7 @@ function! s:base.get(...)
 
 			if self._is_exit()
 				call s:_redraw()
-				return ""
+				return self.getline()
 			endif
 
 			call self._inputkey()


### PR DESCRIPTION
んー微妙な気もするのでダメ元で要望したいのですが、exitさせた時も`getline()`の値を返して欲しいです。現在は`return ""`

現在僕の知る限りでは、exitするのはコマンドラインが空のときに`<C-h>`押した時だけなので結果は変わらないのですが、コードからエンターキーの押下以外でプロンプトを終了させる方法があればより便利だと思います。(というかしたい)

`on_char()`で何かしら処理して、ある条件を満たしたら終了させたい場合とかを想定しています。
空文字列でexitしたい場合は`setline('')`すればいいというのもありますし
