### PR TITLE
Fix module example lacks name

### DIFF
--- a/example/module.vim
+++ b/example/module.vim
@@ -6,7 +6,9 @@ let s:my = s:cmdline.make("$ ")
 
 
 " モジュールの生成
-let s:module = {}
+let s:module = {
+\   "name" : "Custom",
+\}
 
 
 " キーが入力されて文字が挿入される前に呼ばれる関数


### PR DESCRIPTION
たしか、最初に試したとき、s:moduleにはnameが必須で空だとエラー吐きました
