### PR TITLE
Support test by modifying redir messages

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline.vim
+++ b/autoload/vital/__latest__/Over/Commandline.vim
@@ -340,6 +340,9 @@ function! s:_hl_cursor_off()
 		silent highlight Cursor
 		redir END
 		let hl = substitute(matchstr(cursor, 'xxx \zs.*'), '[ \t\n]\+\|cleared', ' ', 'g')
+		if mode(1) == 'ce'
+			let hl = substitute(hl, '\sLast\sset\sfrom.*', '', '')
+		endif
 		if !empty(substitute(hl, '\s', '', 'g'))
 			let s:old_hi_cursor = hl
 		endif


### PR DESCRIPTION
:h mode()
When Normal Ex mode(mode(1) value is 'ce'), `redir` message contains 'Last
set from {path}', so highlight doesn't work.

これこそ、ｵｲｵｲという感じですが、redir使っているコードをvspecなどのテスト(他のテストモジュールは試してませんがNormal Ex modeを使っていれば同じだと思います)で実行させるとredirでリダイレクトさせた`hl`変数にに"Last set from {path}"という余分な情報がついてしまって、依存しているテストが全部落ちてしまいます。

たぶん、他に対処法ないし(`silent!`くらい?)、いまさらテスト全部消すのも嫌なので個人的にはマージされなくても毎回ここだけ書き換えて使うと思います

(おそらく)テストのためだけのコードを混ぜろなんてちゃんちゃらおかしいと思いますが、実質mode(1)かどうか見るという処理しか挟まないので、もしよかったら対応してほしいなぁというダメ元の要望です
