### PR TITLE
Fix condition for handling "Last set from {path}"

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline.vim
+++ b/autoload/vital/__latest__/Over/Commandline.vim
@@ -336,13 +336,16 @@ function! s:_hl_cursor_off()
 	endif
 	let s:old_hi_cursor = "cterm=reverse"
 	if hlexists("Cursor")
-		redir => cursor
-		silent highlight Cursor
-		redir END
+		let save_verbose = &verbose
+		let &verbose = 0
+		try
+			redir => cursor
+			silent highlight Cursor
+			redir END
+		finally
+			let &verbose = save_verbose
+		endtry
 		let hl = substitute(matchstr(cursor, 'xxx \zs.*'), '[ \t\n]\+\|cleared', ' ', 'g')
-		if &verbose != 0
-			let hl = substitute(hl, '\sLast\sset\sfrom.*', '', '')
-		endif
 		if !empty(substitute(hl, '\s', '', 'g'))
 			let s:old_hi_cursor = hl
 		endif


### PR DESCRIPTION
:h :verbose-cmd

When 'verbose' is non-zero, listing the value of a Vim option or a key map or
an abbreviation or a user-defined function or a command or a highlight group
or an autocommand will also display where it was last defined.

PR作り直しました　#10
