### PR TITLE
Fix to depend KeyMapping module

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline.vim
+++ b/autoload/vital/__latest__/Over/Commandline.vim
@@ -15,6 +15,7 @@ let s:modules = [
 \	"Cancel",
 \	"Enter",
 \	"NoInsert",
+\	"KeyMapping",
 \]
 
 let s:modules_snake = [
@@ -29,6 +30,7 @@ let s:modules_snake = [
 \	"cancel",
 \	"enter",
 \	"no_insert",
+\	"key_mapping",
 \]
 
 


### PR DESCRIPTION
KeyMappingモジュールをリストに追加してないせいで`Vitalize`時にKeyMappingモジュールがついてきません。

その意味ではsnakeの方はいらない気もしましたが追加しちゃいました。
