### PR TITLE
Ignore \x80\xfd` input sequence for <expr> mappings

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline/Base.vim
+++ b/autoload/vital/__latest__/Over/Commandline/Base.vim
@@ -466,8 +466,13 @@ endfunction
 
 
 function! s:_getchar(...)
-	let char = call("getchar", a:000)
-	return type(char) == type(0) ? nr2char(char) : char
+	while 1
+		let char = call("getchar", a:000)
+		" Workaround for the <expr> mappings
+		if char !=# "\x80\xfd`"
+			return type(char) == type(0) ? nr2char(char) : char
+		endif
+	endwhile
 endfunction
 
 


### PR DESCRIPTION
何故か`<expr>` マッピングで `getchar()` を呼ぶと

```
 <80><fd>`
```

という制御文字(?)が端末から自動的に送られてきて`getchar()`の入力が勝手に
終わってしまいます.

なので、workaroundですが、この入力を無視するようにするパッチです。

gVimではどうだとかはまだよく調べてません

ももんが部屋のログですが一応ログ: http://lingr.com/room/momonga/archives/2014/08/09#message-19893398
