### PR TITLE
Fix history to be compatible with default one

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline/Modules/History.vim
+++ b/autoload/vital/__latest__/Over/Commandline/Modules/History.vim
@@ -36,8 +36,8 @@ function! s:module.on_char_pre(cmdline)
 		\	|| s:is_match_mode != s:_should_match_cmdline(a:cmdline)
 			let cmdline = '^' . a:cmdline.getline()
 			let s:is_match_mode = s:_should_match_cmdline(a:cmdline)
-			let s:cmdhist = s:is_match_mode ?
-			\	filter(self.histories(), 'v:val =~ cmdline') : self.histories()
+			let s:cmdhist = [a:cmdline.getline()] + (s:is_match_mode ?
+			\	filter(self.histories(), 'v:val =~ cmdline') : self.histories())
 		endif
 	endif
 	call a:cmdline.setchar("")


### PR DESCRIPTION
- issue #55 のfix
- 同時に履歴の長さが1しかないときに`<Up>`で遡れない問題が直ってる
  - `s:cmdline`の長さが1の時は,
    最初の`<Up>`でインデックス0番を呼ばなければならないけど,
    問答無用でカウントが`+1` されてしまっていた
  - 今回の修正で先頭に入力したコマンドラインのテキストが挿入されることでこの問題が副作用的に直ってる
  - (流石にこのpull-requestを分けるのは遠慮したいデス. インデックス弄る変更してもっかいその変更直すことになる)
