### PR TITLE
Fix history not to insert empty pattern by histget(0) 

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline/Modules/History.vim
+++ b/autoload/vital/__latest__/Over/Commandline/Modules/History.vim
@@ -8,7 +8,7 @@ let s:module = {
 \}
 
 function! s:module.histories()
-	return map(range(&history), 'histget(self.mode, v:val * -1)')
+	return map(range(1, &history), 'histget(self.mode, v:val * -1)')
 endfunction
 
 function! s:_should_match_cmdline(cmdline)


### PR DESCRIPTION
すいません #61 でエンバグして コマンドラインが空の時の最初の`<Up>`, もしくは 最初の`<C-p>`で1つめの履歴が正しく呼び出されないようになってしまっていました。包括的な確認怠ってましたｽﾐﾏｾﾇｽﾐﾏｾﾇ... :bow: 

`range(数字)` で生成したものを`map`で`histget()`していることにより, 毎回存在しない0インデックスのhistoryが`histget(type, 0)`によって呼ばれて、存在シない場合は空文字`''`が返ってくるのが原因でしたので不必要な0番目は呼ばないようにしました。
