### PR TITLE
Add resettable InsertRegister

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline/Modules/InsertRegister.vim
+++ b/autoload/vital/__latest__/Over/Commandline/Modules/InsertRegister.vim
@@ -118,5 +118,18 @@ function! s:make()
 	return deepcopy(s:module)
 endfunction
 
+let s:resettable = deepcopy(s:module)
+
+function! s:resettable.on_char_pre(cmdline)
+	call call(s:module.on_char_pre, [a:cmdline], self)
+	if a:cmdline.is_input("\<C-r>") && &incsearch
+		call self.reset()
+	endif
+endfunction
+
+function! s:make_resettable()
+	return deepcopy(s:resettable)
+endfunction
+
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
http://lingr.com/room/vim/archives/2014/11/02#message-20520694

`InsertRegister` でつかわれる`<cword>`などを固定せずresetするようにしたバージョンです
