### PR TITLE
KeyMappingのescape_key()にダブルクオートが入っていても落ちないようにfix

### DIFF
--- a/autoload/vital/__latest__/Over/Keymapping.vim
+++ b/autoload/vital/__latest__/Over/Keymapping.vim
@@ -18,7 +18,7 @@ endfunction
 
 
 function! s:escape_key(key)
-	execute 'let result = "' . substitute(escape(a:key, '\'), '\(<.\{-}>\)', '\\\1', 'g') . '"'
+	execute 'let result = "' . substitute(escape(a:key, '\"'), '\(<.\{-}>\)', '\\\1', 'g') . '"'
 	return result
 endfunction
 


### PR DESCRIPTION
`cnoremap <C-q> <C-R>=expand("%:p:h") . "/" <CR>`

というような`"`が含まれるマッピングをしているとおそらく`execute`周りか何かでクオートがなくなりエラーになってしまっていました。エスケープすることでfix
