### PR TITLE
Modules/KeyMapping: add default value

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline/Modules/KeyMapping.vim
+++ b/autoload/vital/__latest__/Over/Commandline/Modules/KeyMapping.vim
@@ -81,7 +81,8 @@ endfunction
 
 
 let s:vim_cmdline_mapping = {
-\	"name" : "KeyMapping_vim_cmdline_mapping"
+\	"name" : "KeyMapping_vim_cmdline_mapping",
+\	"_cmaps" : {}
 \}
 
 function! s:_auto_cmap()


### PR DESCRIPTION
``` vim
call vital#of("vital").unload()
let s:V = vital#of("vital")
let s:Cmdline = s:V.import("Over.Commandline")
let s:modules = s:V.import('Over.Commandline.Modules')

let cmdline = s:Cmdline.make_standard()
call cmdline._init_variables()
call cmdline.connect(s:modules.get('KeyMapping').make_vim_cmdline_mapping())
call cmdline.cnoremap("h", "ho\<Esc>mu")
call cmdline._input("h")
echo cmdline.getline() == "ho"
echo cmdline.input_key_stack_string() == "mu"
```

こういう感じでテストするときとか, なんらかの形で on_enter 呼ばれる前に `keymapping()` 呼ばれると変数なくて落ちるので修正です
