### PR TITLE
NoInsert: fix priority

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline/Modules/NoInsert.vim
+++ b/autoload/vital/__latest__/Over/Commandline/Modules/NoInsert.vim
@@ -12,6 +12,9 @@ function! s:module.is_no_insert(char)
 	return index(self.chars, a:char) >= 0
 endfunction
 
+function! s:module.priority(event)
+	return a:event is "on_char_pre" ? -10 : 0
+endfunction
 
 function! s:module.on_char_pre(cmdline)
 	if self.is_no_insert(a:cmdline.char())


### PR DESCRIPTION
ref: #110

優先度が指定されていないせいで, digraph や #110 の `<C-v>` で明示的に特殊キーを入力したくても, 入力できるかどうか運任せになってしまってました.

digraphs はたまたま大丈夫だったっぽいですが #110 は NoInsert で上書きされて入力できなかった