### PR TITLE
Module.KeyMapping: fix <SID> handling

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline/Modules/KeyMapping.vim
+++ b/autoload/vital/__latest__/Over/Commandline/Modules/KeyMapping.vim
@@ -85,6 +85,10 @@ let s:vim_cmdline_mapping = {
 \	"_cmaps" : {}
 \}
 
+function! s:_convert_sid(rhs, sid) abort
+	return substitute(a:rhs, '<SID>', '<SNR>' . a:sid . '_', 'g')
+endfunction
+
 function! s:_auto_cmap()
 	let cmaps = {}
 	let cmap_info = s:Keymapping.rhs_key_list("c", 0, 1)
@@ -92,7 +96,7 @@ function! s:_auto_cmap()
 	for c in filter(cmap_info, "v:val['buffer'] ==# 0")
 		let cmaps[s:Keymapping.escape_special_key(c['lhs'])] = {
 		\   'noremap' : c['noremap'],
-		\   'key'  : s:Keymapping.escape_special_key(c['rhs']),
+		\   'key'  : s:Keymapping.escape_special_key(s:_convert_sid(c['rhs'], c['sid'])),
 		\   'expr' : s:Keymapping.escape_special_key(c['expr']),
 		\ }
 	endfor

--- a/autoload/vital/__latest__/Over/Commandline/Modules/KeyMapping.vim
+++ b/autoload/vital/__latest__/Over/Commandline/Modules/KeyMapping.vim
@@ -85,10 +85,6 @@ let s:vim_cmdline_mapping = {
 \	"_cmaps" : {}
 \}
 
-function! s:_convert_sid(rhs, sid) abort
-	return substitute(a:rhs, '<SID>', '<SNR>' . a:sid . '_', 'g')
-endfunction
-
 function! s:_auto_cmap()
 	let cmaps = {}
 	let cmap_info = s:Keymapping.rhs_key_list("c", 0, 1)
@@ -96,7 +92,7 @@ function! s:_auto_cmap()
 	for c in filter(cmap_info, "v:val['buffer'] ==# 0")
 		let cmaps[s:Keymapping.escape_special_key(c['lhs'])] = {
 		\   'noremap' : c['noremap'],
-		\   'key'  : s:Keymapping.escape_special_key(s:_convert_sid(c['rhs'], c['sid'])),
+		\   'key'  : s:Keymapping.escape_special_key(s:Keymapping.convert_sid(c['rhs'], c['sid'])),
 		\   'expr' : s:Keymapping.escape_special_key(c['expr']),
 		\ }
 	endfor


### PR DESCRIPTION
`maparg()` の `rhs` は
`<SID>`のまま入っていたのでそこをちゃんと変換するようにしました.

palette でやるべきな気もする(けど, paletteは `maparg()`の返り値を返して欲しいという思いもある)のでそのへんはおしょーさんの意見を伺いたいです