### PR TITLE
Fix split special keys

### DIFF
--- a/autoload/vital/__latest__/Over/String.vim
+++ b/autoload/vital/__latest__/Over/String.vim
@@ -118,8 +118,8 @@ let s:_engine = exists("+regexpengine") ? '\%#=2' : ''
 " \<A-]> => Û\xfdQ
 " \<A-@> => À\xfeX
 let s:_regex = exists("+regexpengine")
-\	? "Û\xfdQ\\zs\\|À\xfeX\\zs\\|\x80\xfc.\\%(\x80..\\|.\\)\\zs\\|\x80..\\zs\\|.\\zs"
-\	: "Û[\xfd]Q\\zs\\|À[\xfe]X\\zs\\|[\x80][\xfc].\\%([\x80]..\\|.\\)\\zs\\|[\x80]..\\zs\\|.\\zs"
+\	? "\\%(Û\xfdQ\\|À\xfeX\\|\x80\xfc.\\%(\x80..\\|.\\)\\|\x80..\\|.\\)\\zs"
+\	: "\\%(Û[\xfd]Q\\|À[\xfe]X\\|[\x80][\xfc].\\%([\x80]..\\|.\\)\\|[\x80]..\\|.\\)\\zs"
 function! s:_split_keystring(str, ...)
 	return split(a:str, s:_engine . '\m\%(' . get(a:, 1, '') . s:_regex . '\)')
 endfunction

--- a/autoload/vital/__latest__/Over/String.vim
+++ b/autoload/vital/__latest__/Over/String.vim
@@ -115,9 +115,11 @@ endfunction
 " :echo "\x80" =~ "\\%#=1[\x80]" | " => 1
 " http://lingr.com/room/vim/archives/2015/02/13#message-21261450
 let s:_engine = exists("+regexpengine") ? '\%#=2' : ''
+" \<A-]> => Û\xfdQ
+" \<A-@> => À\xfeX
 let s:_regex = exists("+regexpengine")
-\	? "\x80\xfc.\\%(\x80..\\|.\\)\\zs\\|\x80..\\zs\\|.\\zs"
-\	: "[\x80][\xfc].\\%([\x80]..\\|.\\)\\zs\\|[\x80]..\\zs\\|.\\zs"
+\	? "Û\xfdQ\\zs\\|À\xfeX\\zs\\|\x80\xfc.\\%(\x80..\\|.\\)\\zs\\|\x80..\\zs\\|.\\zs"
+\	: "Û[\xfd]Q\\zs\\|À[\xfe]X\\zs\\|[\x80][\xfc].\\%([\x80]..\\|.\\)\\zs\\|[\x80]..\\zs\\|.\\zs"
 function! s:_split_keystring(str, ...)
 	return split(a:str, s:_engine . '\m\%(' . get(a:, 1, '') . s:_regex . '\)')
 endfunction

--- a/test/Over/String.vim
+++ b/test/Over/String.vim
@@ -22,6 +22,8 @@ function! s:_test_split()
 	OwlCheck s:split_by_keys("\<A-Space>\<CR>\<A-Down>") == ["\<A-Space>", "\<CR>", "\<A-down>"]
 	OwlCheck s:split_by_keys("234567") == ["2", "3", "4", "5", "6", "7"]
 	OwlCheck s:split_by_keys("<Over>(exit)aa") == ["<Over>(exit)", "a", "a"]
+	OwlCheck s:split_by_keys("aa\<A-[>aa\<C-a>") == ['a', 'a', "\<A-[>", 'a', 'a', "\<C-a>"]
+	OwlCheck s:split_by_keys("aa\<A-@>aa\<C-a>") == ['a', 'a', "\<A-@>", 'a', 'a', "\<C-a>"]
 endfunction
 
 


### PR DESCRIPTION
### やったこと

- :heavy_check_mark:  #121 の問題を解決(無理やり)
- :heavy_check_mark: 正規表現をちょっとだけカイゼン
- :heavy_check_mark:  #121 の問題のテスト追加

### おもったこと
テスト手動でOwlRunしにいくのめんどい(かつパスが通ってないと実行できない) という不便さあるので themis + Vital.Vim.ScriptLocal でテストするPRとか投げたらﾏｯｼﾞ & travis etc...でCIまわしていただけたりします? (まぁすぐやるとは言ってないけど)