### PR TITLE
Module.Digraphs: Avoid flicker on_enter

### DIFF
--- a/autoload/vital/__latest__/Over/Commandline/Modules/Digraphs.vim
+++ b/autoload/vital/__latest__/Over/Commandline/Modules/Digraphs.vim
@@ -46,12 +46,18 @@ function! s:digraph() abort
 endfunction
 
 
-function! s:module.on_enter(cmdline)
-	let self.digraphs = s:digraph()
+function! s:module.on_leave(cmdline)
+	" Delete cache to handle additional digraphs definition
+	let self.digraphs = {}
 endfunction
 
 function! s:module.on_char_pre(cmdline)
 	if a:cmdline.is_input("\<C-k>")
+		if empty(self.digraphs)
+			" Get digraphs when inputting <C-k> instead of on_enter because it cause
+			" flicker in some environments #107
+			let self.digraphs = s:digraph()
+		endif
 		call a:cmdline.setchar('?')
 		let self.prefix_key = a:cmdline.input_key()
 		let self.old_line = a:cmdline.getline()


### PR DESCRIPTION
ref: #107

### やったこと
- :ballot_box_with_check: `:digraphs` のcaptureを`on_enter`ではなく`<C-k>`押下時に実行するように変更
- :ballot_box_with_check: Linux gvim 7.4.663 において`incsearch.vim`(vital-over使用プラグイン)の起動時に画面のチラツキがなくなったことを確認
- :ballot_box_with_check: `:digraphs` 毎回`<C-k>`押下時にcaptureするのも冗長なので，`on_leave`時まではキャッシュ．`on_leave`でキャッシュを消すのは
`:dig[raphs] {char1}{char2} {number}` で定義された`digraph`に対応するため (これはある意味前からだけど)

#### 補足
- なお`<C-k>`押下時にはちらつきます
- incsearch.vim で試す場合は `:IncSearchNoreMap <C-k> <C-k>` する必要あり．
